### PR TITLE
fix: remove cap strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If they are not executable then use the command `chmod +x <file name>`
 The docker compose configuration contains settings for the following services:
 
 - `postgresdb` generic postgresql db
-- `pgadmin` UI admin for Postgres, login as capgemini@capgemini.com/mysecretpassword
+- `pgadmin` UI admin for Postgres, login as user@example.com/mysecretpassword
 - `traefik` reverse proxy
 - `keycloak-app` Access and Identity Management Tool
 - OneCX portal products with its MS

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
   pgadmin:
     image: ${PGADMIN}
     environment:
-      PGADMIN_DEFAULT_EMAIL: capgemini@capgemini.com
+      PGADMIN_DEFAULT_EMAIL: user@example.com
       PGADMIN_DEFAULT_PASSWORD: mysecretpassword
     volumes:
       - ./init-data/pgadmin/servers.json:/pgadmin4/servers.json


### PR DESCRIPTION
example.com is safe to use according to https://developers.google.com/style/examples